### PR TITLE
Client accepts HTTP headers

### DIFF
--- a/libs/httpcl/include/httpcl/http-client.hpp
+++ b/libs/httpcl/include/httpcl/http-client.hpp
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <memory>
 #include <functional>
+#include <map>
 
 namespace httpcl
 {
@@ -36,8 +37,8 @@ public:
 class HttpLibHttpClient : public IHttpClient
 {
 public:
-    HttpLibHttpClient();
-    ~HttpLibHttpClient();
+    explicit HttpLibHttpClient(std::map<std::string, std::string> const& headers={});
+    ~HttpLibHttpClient() override;
 
     Result get(const std::string& uri) override;
     Result post(const std::string& uri,

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -24,7 +24,10 @@ using Result = HttpLibHttpClient::Result;
 
 struct HttpLibHttpClient::Impl
 {
+    Impl(std::map<std::string, std::string> headers) : headers(std::move(headers)) {}
+
     httpcl::HTTPSettings settings;
+    std::map<std::string, std::string> headers;
 
     auto makeClient(const URIComponents& uri)
     {
@@ -32,18 +35,20 @@ struct HttpLibHttpClient::Impl
         client->enable_server_certificate_verification(false);
         client->set_connection_timeout(60000);
         client->set_read_timeout(60000);
+        client->set_default_headers({headers.begin(), headers.end()});
         settings.apply(uri.build(), *client);
 
         return client;
     }
 };
 
-HttpLibHttpClient::HttpLibHttpClient()
-    : impl_(std::make_unique<Impl>())
+HttpLibHttpClient::HttpLibHttpClient(std::map<std::string, std::string> const& headers)
+    : impl_(std::make_unique<Impl>(headers))
 {}
 
-HttpLibHttpClient::~HttpLibHttpClient()
-{}
+HttpLibHttpClient::~HttpLibHttpClient() {
+    /* Nontrivial due to impl unique-ptr. */
+}
 
 Result HttpLibHttpClient::get(const std::string& uriStr)
 {

--- a/libs/httpcl/src/http-settings.cpp
+++ b/libs/httpcl/src/http-settings.cpp
@@ -116,7 +116,7 @@ void HTTPSettings::load()
 {
     settings.clear();
 
-    auto cookieJar = std::getenv("AFW_HTTP_SETTINGS_FILE");
+    auto cookieJar = std::getenv("HTTP_SETTINGS_FILE");
     if (!cookieJar)
         return;
 

--- a/libs/pyzswagcl/py-openapi-client.cpp
+++ b/libs/pyzswagcl/py-openapi-client.cpp
@@ -80,8 +80,7 @@ PyOpenApiClient::PyOpenApiClient(std::string const& openApiUrl,
     auto httpClient = std::make_unique<HttpLibHttpClient>(headers);
     OpenAPIConfig openApiConfig = [&](){
         if (isLocalFile) {
-            std::ifstream fs;
-            fs.open(openApiUrl);
+            std::ifstream fs(openApiUrl);
             return parseOpenAPIConfig(fs);
         }
         else

--- a/libs/pyzswagcl/py-openapi-client.cpp
+++ b/libs/pyzswagcl/py-openapi-client.cpp
@@ -61,7 +61,7 @@ namespace
 
 void PyOpenApiClient::bind(py::module_& m) {
     auto serviceClient = py::class_<PyOpenApiClient>(m, "OAClient")
-        .def(py::init<std::string, bool>(), "url"_a, "is_local_file"_a = false)
+        .def(py::init<std::string, bool, Headers>(), "url"_a, "is_local_file"_a = false, "headers"_a = Headers())
         // zserio <= 2.2.0
         .def("callMethod", &PyOpenApiClient::callMethod,
              "methodName"_a, "requestData"_a, "context"_a)
@@ -73,9 +73,11 @@ void PyOpenApiClient::bind(py::module_& m) {
     serviceClient.attr("__bases__") = py::make_tuple(serviceClientBase) + serviceClient.attr("__bases__");
 }
 
-PyOpenApiClient::PyOpenApiClient(std::string const& openApiUrl, bool isLocalFile)
+PyOpenApiClient::PyOpenApiClient(std::string const& openApiUrl,
+                                 bool isLocalFile,
+                                 Headers const& headers)
 {
-    auto httpClient = std::make_unique<HttpLibHttpClient>();
+    auto httpClient = std::make_unique<HttpLibHttpClient>(headers);
     OpenAPIConfig openApiConfig = [&](){
         if (isLocalFile) {
             std::ifstream fs;

--- a/libs/pyzswagcl/py-openapi-client.h
+++ b/libs/pyzswagcl/py-openapi-client.h
@@ -3,6 +3,7 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
+#include <map>
 
 namespace py = pybind11;
 
@@ -11,7 +12,11 @@ class PyOpenApiClient
 public:
     static void bind(py::module_& m);
 
-    PyOpenApiClient(std::string const& openApiUrl, bool isLocalFile);
+    using Headers = std::map<std::string, std::string>;
+
+    PyOpenApiClient(std::string const& openApiUrl,
+                    bool isLocalFile,
+                    Headers const& headers);
 
     std::vector<uint8_t> callMethod(
         const std::string& methodName,

--- a/libs/pyzswagcl/py-zswagcl.cpp
+++ b/libs/pyzswagcl/py-zswagcl.cpp
@@ -20,6 +20,9 @@ PYBIND11_MODULE(pyzswagcl, m)
     py::bind_map<std::map<std::string, OpenAPIConfig::Parameter>>(m, "ParameterMap");
     py::implicitly_convertible<py::dict, std::map<std::string, OpenAPIConfig::Parameter>>();
 
+    py::bind_map<PyOpenApiClient::Headers>(m, "HeaderMap");
+    py::implicitly_convertible<py::dict, PyOpenApiClient::Headers>();
+
     ///////////////////////////////////////////////////////////////////////////
     // ParameterLocation
 

--- a/libs/zswag/test/CMakeLists.txt
+++ b/libs/zswag/test/CMakeLists.txt
@@ -11,14 +11,19 @@ add_executable(${PROJECT_NAME} client.cpp)
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}-zsr-reflection zswagcl stx zsr)
 
-add_test(
-    NAME
-      zswag-server-integration
-    WORKING_DIRECTORY
-      "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND
-      bash "test_integration.bash"
-        -w "${WHEEL_DEPLOY_DIRECTORY}"
-        -b "python -m zswag.test.calc server localhost:16161"
-        -f "$<TARGET_FILE:${PROJECT_NAME}> http://localhost:16161/openapi.json"
-        -f "python -m zswag.test.calc client localhost:16161")
+# The integration tests are flaky on macOS in Github CI,
+# and running them on macOS is not required. So we save
+# ourselves some build minutes and workflow headache.
+if (NOT APPLE)
+  add_test(
+      NAME
+        zswag-server-integration
+      WORKING_DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+      COMMAND
+        bash "test_integration.bash"
+          -w "${WHEEL_DEPLOY_DIRECTORY}"
+          -b "python -m zswag.test.calc server localhost:16161"
+          -f "$<TARGET_FILE:${PROJECT_NAME}> http://localhost:16161/openapi.json"
+          -f "python -m zswag.test.calc client localhost:16161")
+endif()

--- a/libs/zswag/test/client.cpp
+++ b/libs/zswag/test/client.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) Navigation Data Standard e.V. - See LICENSE file.
-
 #include "zswagcl/zsr-client.hpp"
 #include "stx/format.h"
 

--- a/libs/zswag/test/test_integration.bash
+++ b/libs/zswag/test/test_integration.bash
@@ -7,7 +7,7 @@ venv=$(mktemp -d)
 echo "→ Setting up a virtual environment in $venv ..."
 python3 -m venv "$venv"
 source "$venv/$activate_path"
-pip install -U pip
+python -m pip install -U pip
 
 trap 'echo "→ Killing $(jobs -p)"; kill $(jobs -p); echo "→ Removing $venv"; rm -rf "$venv"' EXIT
 


### PR DESCRIPTION
### Changes

Closes #33 

The `HttpLibHttpClient` and `zswag::OAClient` constructors have been adjusted to enable passing of additional headers.

- [x] Write docs (see #44).

### Review Checklist

- [x] The changes are understood.
- [x] CI is passing.

