### PR TITLE
Add ZSWAG_DISABLE_TESTING 🔨 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
+
+if (NOT PROJECT_NAME)
+  set (ZSWAG_ENABLE_TESTING ON)
+endif()
+
 project(zswag)
 enable_testing()
 

--- a/libs/httpcl/test/CMakeLists.txt
+++ b/libs/httpcl/test/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(httpcl-test
     zsr
     Catch2::Catch2)
 
-include(CTest)
-add_test(NAME httpcl-test
-  COMMAND "$<TARGET_FILE:httpcl-test>")
+if (ZSWAG_ENABLE_TESTING)
+  add_test(NAME httpcl-test
+    COMMAND "$<TARGET_FILE:httpcl-test>")
+endif()

--- a/libs/zswag/test/CMakeLists.txt
+++ b/libs/zswag/test/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(${PROJECT_NAME}
 # The integration tests are flaky on macOS in Github CI,
 # and running them on macOS is not required. So we save
 # ourselves some build minutes and workflow headache.
-if (NOT APPLE)
+if (ZSWAG_ENABLE_TESTING AND NOT APPLE)
   add_test(
       NAME
         zswag-server-integration

--- a/libs/zswagcl/test/CMakeLists.txt
+++ b/libs/zswagcl/test/CMakeLists.txt
@@ -24,6 +24,8 @@ target_compile_definitions(zswagcl-test
   PRIVATE
     -DTESTDATA="${CMAKE_CURRENT_LIST_DIR}/testdata/")
 
-include(CTest)
-add_test(NAME zswagcl-test
-  COMMAND "$<TARGET_FILE:zswagcl-test>")
+
+if (ZSWAG_ENABLE_TESTING)
+  add_test(NAME zswagcl-test
+    COMMAND "$<TARGET_FILE:zswagcl-test>")
+endif()


### PR DESCRIPTION
Add ZSWAG_ENABLE_TESTING, allowing dependents to disable integration tests .