### PR TITLE
Support for header params, passing custom HTTP configs

### DIFF
--- a/libs/httpcl/include/httpcl/http-client.hpp
+++ b/libs/httpcl/include/httpcl/http-client.hpp
@@ -7,6 +7,9 @@
 #include <map>
 #include <stdexcept>
 
+#include "http-settings.hpp"
+#include "uri.hpp"
+
 namespace httpcl
 {
 
@@ -21,48 +24,58 @@ public:
     struct Error : std::runtime_error {
         Result result;
 
-        Error(Result result, std::string message)
-            : std::runtime_error(std::move(message))
+        Error(Result result, std::string const& message)
+            : std::runtime_error(message)
             , result(std::move(result))
         {}
     };
 
     virtual ~IHttpClient() = default;
 
-    virtual Result get(const std::string& path) = 0;
+    virtual Result get(const std::string& path,
+                       const Config& config) = 0;
     virtual Result post(const std::string& path,
                         const std::string& body,
-                        const std::string& bodyType) = 0;
+                        const std::string& bodyType,
+                        const Config& config) = 0;
     virtual Result put(const std::string& path,
                        const std::string& body,
-                       const std::string& bodyType) = 0;
+                       const std::string& bodyType,
+                       const Config& config) = 0;
     virtual Result del(const std::string& path,
                        const std::string& body,
-                       const std::string& bodyType) = 0;
+                       const std::string& bodyType,
+                       const Config& config) = 0;
     virtual Result patch(const std::string& path,
                          const std::string& body,
-                         const std::string& bodyType) = 0;
+                         const std::string& bodyType,
+                         const Config& config) = 0;
 };
 
 class HttpLibHttpClient : public IHttpClient
 {
 public:
-    explicit HttpLibHttpClient(std::map<std::string, std::string> const& headers={});
+    explicit HttpLibHttpClient(Config const& config={});
     ~HttpLibHttpClient() override;
 
-    Result get(const std::string& uri) override;
+    Result get(const std::string& uri,
+               const Config& config) override;
     Result post(const std::string& uri,
                 const std::string& body,
-                const std::string& bodyType) override;
+                const std::string& bodyType,
+                const Config& config) override;
     Result put(const std::string& uri,
                const std::string& body,
-               const std::string& bodyType) override;
+               const std::string& bodyType,
+               const Config& config) override;
     Result del(const std::string& uri,
                const std::string& body,
-               const std::string& bodyType) override;
+               const std::string& bodyType,
+               const Config& config) override;
     Result patch(const std::string& uri,
                  const std::string& body,
-                 const std::string& bodyType) override;
+                 const std::string& bodyType,
+                 const Config& config) override;
 
 private:
     struct Impl;
@@ -77,19 +90,24 @@ public:
                                       std::string_view /* body */,
                                       std::string_view /* type */)> postFun;
 
-    Result get(const std::string& uri) override;
+    Result get(const std::string& uri,
+               const Config& config) override;
     Result post(const std::string& uri,
                 const std::string& body,
-                const std::string& bodyType) override;
+                const std::string& bodyType,
+                const Config& config) override;
     Result put(const std::string& uri,
                const std::string& body,
-               const std::string& bodyType) override;
+               const std::string& bodyType,
+               const Config& config) override;
     Result del(const std::string& uri,
                const std::string& body,
-               const std::string& bodyType) override;
+               const std::string& bodyType,
+               const Config& config) override;
     Result patch(const std::string& uri,
                  const std::string& body,
-                 const std::string& bodyType) override;
+                 const std::string& bodyType,
+                 const Config& config) override;
 };
 
 }

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -15,6 +15,11 @@ httpcl::IHttpClient::Result makeResult(httplib::Result&& result)
     return {0, {}};
 }
 
+void applyQuery(httpcl::URIComponents& uri, httpcl::Config const& config) {
+    for (auto const& [key, value] : config.query)
+        uri.addQuery(key, value);
+}
+
 }
 
 namespace httpcl
@@ -24,110 +29,140 @@ using Result = HttpLibHttpClient::Result;
 
 struct HttpLibHttpClient::Impl
 {
-    Impl(std::map<std::string, std::string> headers) : headers(std::move(headers)) {}
+    explicit Impl(Config config) : userConfig_(std::move(config)) {}
 
-    httpcl::HTTPSettings settings;
-    std::map<std::string, std::string> headers;
+    Config userConfig_;
 
-    auto makeClient(const URIComponents& uri)
+    auto makeClientAndApplyQuery(URIComponents& uri, Config const& config)
     {
         auto client = std::make_unique<httplib::Client>(uri.buildHost().c_str());
         client->enable_server_certificate_verification(false);
         client->set_connection_timeout(60000);
         client->set_read_timeout(60000);
-        settings.apply(uri.build(), *client, headers);
+
+        // First fetch persistent config for this URI,
+        // then apply user-specified config overrides.
+        auto uriSpecificConfig = config;
+        uriSpecificConfig |= userConfig_;
+        uriSpecificConfig.apply(*client);
+
+        applyQuery(uri, config);
 
         return client;
     }
 };
 
-HttpLibHttpClient::HttpLibHttpClient(std::map<std::string, std::string> const& headers)
-    : impl_(std::make_unique<Impl>(headers))
+HttpLibHttpClient::HttpLibHttpClient(Config const& config)
+    : impl_(std::make_unique<Impl>(config))
 {}
 
 HttpLibHttpClient::~HttpLibHttpClient() {
     /* Nontrivial due to impl unique-ptr. */
 }
 
-Result HttpLibHttpClient::get(const std::string& uriStr)
+Result HttpLibHttpClient::get(const std::string& uriStr,
+                              const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(impl_->makeClient(uri)->Get(uri.buildPath().c_str()));
+    return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Get(
+        uri.buildPath().c_str(),
+        {config.headers.begin(), config.headers.end()}));
 }
 
 Result HttpLibHttpClient::post(const std::string& uriStr,
                                const std::string& body,
-                               const std::string& bodyType)
+                               const std::string& bodyType,
+                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(impl_->makeClient(uri)->Post(uri.buildPath().c_str(),
-                                                   body,
-                                                   bodyType.c_str()));
+    return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Post(
+        uri.buildPath().c_str(),
+        {config.headers.begin(), config.headers.end()},
+        body,
+        bodyType.c_str()));
 }
 
 Result HttpLibHttpClient::put(const std::string& uriStr,
                               const std::string& body,
-                              const std::string& bodyType)
+                              const std::string& bodyType,
+                              const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(impl_->makeClient(uri)->Put(uri.buildPath().c_str(),
-                                                  body,
-                                                  bodyType.c_str()));
+    return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Put(
+        uri.buildPath().c_str(),
+        {config.headers.begin(), config.headers.end()},
+        body,
+        bodyType.c_str()));
 }
 
 Result HttpLibHttpClient::del(const std::string& uriStr,
                               const std::string& body,
-                              const std::string& bodyType)
+                              const std::string& bodyType,
+                              const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(impl_->makeClient(uri)->Delete(uri.buildPath().c_str(),
-                                                     body,
-                                                     bodyType.c_str()));
+    return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Delete(
+        uri.buildPath().c_str(),
+        {config.headers.begin(), config.headers.end()},
+        body,
+        bodyType.c_str()));
 }
 
 Result HttpLibHttpClient::patch(const std::string& uriStr,
                                 const std::string& body,
-                                const std::string& bodyType)
+                                const std::string& bodyType,
+                                const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
-    return makeResult(impl_->makeClient(uri)->Patch(uri.buildPath().c_str(),
-                                                    body,
-                                                    bodyType.c_str()));
+    return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Patch(
+        uri.buildPath().c_str(),
+        {config.headers.begin(), config.headers.end()},
+        body,
+        bodyType.c_str()));
 }
 
-Result MockHttpClient::get(const std::string& uri)
+Result MockHttpClient::get(const std::string& uri,
+                           const Config& config)
 {
+    auto uriWithQuery = URIComponents::fromStrRfc3986(uri);
+    applyQuery(uriWithQuery, config);
     if (getFun)
-        return getFun(uri);
+        return getFun(uriWithQuery.build());
     return {0, ""};
 }
 
 Result MockHttpClient::post(const std::string& uri,
                             const std::string& body,
-                            const std::string& bodyType)
+                            const std::string& bodyType,
+                            const Config& config)
 {
+    auto uriWithQuery = URIComponents::fromStrRfc3986(uri);
+    applyQuery(uriWithQuery, config);
     if (postFun)
-        return postFun(uri, body, bodyType);
+        return postFun(uriWithQuery.build(), body, bodyType);
     return {0, ""};
 }
 
 Result MockHttpClient::put(const std::string& uri,
                            const std::string& body,
-                           const std::string& bodyType)
+                           const std::string& bodyType,
+                           const Config& config)
 {
     return {0, ""};
 }
 
 Result MockHttpClient::del(const std::string& uri,
                            const std::string& body,
-                           const std::string& bodyType)
+                           const std::string& bodyType,
+                           const Config& config)
 {
     return {0, ""};
 }
 
 Result MockHttpClient::patch(const std::string& uri,
                              const std::string& body,
-                             const std::string& bodyType)
+                             const std::string& bodyType,
+                             const Config& config)
 {
     return {0, ""};
 }

--- a/libs/pyzswagcl/py-openapi-client.cpp
+++ b/libs/pyzswagcl/py-openapi-client.cpp
@@ -65,7 +65,7 @@ namespace
 
 void PyOpenApiClient::bind(py::module_& m) {
     auto serviceClient = py::class_<PyOpenApiClient>(m, "OAClient")
-        .def(py::init<std::string, bool, Headers>(), "url"_a, "is_local_file"_a = false, "headers"_a = Headers())
+        .def(py::init<std::string, bool, httpcl::Config>(), "url"_a, "is_local_file"_a = false, "config"_a = httpcl::Config())
         // zserio >= 2.3.0
         .def("call_method", &PyOpenApiClient::callMethod,
              "method_name"_a, "request"_a, "unused"_a);
@@ -76,9 +76,9 @@ void PyOpenApiClient::bind(py::module_& m) {
 
 PyOpenApiClient::PyOpenApiClient(std::string const& openApiUrl,
                                  bool isLocalFile,
-                                 Headers const& headers)
+                                 httpcl::Config const& config)
 {
-    auto httpClient = std::make_unique<HttpLibHttpClient>(headers);
+    auto httpClient = std::make_unique<HttpLibHttpClient>(config);
     OpenAPIConfig openApiConfig = [&](){
         if (isLocalFile) {
             std::ifstream fs(openApiUrl);

--- a/libs/pyzswagcl/py-openapi-client.h
+++ b/libs/pyzswagcl/py-openapi-client.h
@@ -16,7 +16,7 @@ public:
 
     PyOpenApiClient(std::string const& openApiUrl,
                     bool isLocalFile,
-                    Headers const& headers);
+                    httpcl::Config const& config);
 
     std::vector<uint8_t> callMethod(
         const std::string& methodName,

--- a/libs/pyzswagcl/py-zswagcl.cpp
+++ b/libs/pyzswagcl/py-zswagcl.cpp
@@ -65,7 +65,37 @@ PYBIND11_MODULE(pyzswagcl, m)
             ;
 
     ///////////////////////////////////////////////////////////////////////////
-    // HTTPService::Config
+    // httpcl::Config
+
+    py::class_<httpcl::Config>(m, "HTTPConfig")
+        .def(py::init<>())
+        .def("header", [](httpcl::Config& self, std::string const& key, std::string const& value) {
+            self.headers.insert({key, value});
+            return &self;
+        }, "key"_a, "val"_a)
+        .def("query", [](httpcl::Config& self, std::string const& key, std::string const& value) {
+            self.query.insert({key, value});
+            return &self;
+        }, "key"_a, "val"_a)
+        .def("cookie", [](httpcl::Config& self, std::string const& key, std::string const& value) {
+            self.cookies.insert({key, value});
+            return &self;
+        }, "key"_a, "val"_a)
+        .def("basic_auth", [](httpcl::Config& self, std::string const& user, std::string const& pw) {
+            self.auth = httpcl::Config::BasicAuthentication{
+                user, pw, ""
+            };
+            return &self;
+        }, "user"_a, "pw"_a)
+        .def("proxy", [](httpcl::Config& self, std::string const& host, int port, std::string const& user={}, std::string const& pw={}) {
+            self.proxy = httpcl::Config::Proxy{
+                host, port, user, pw, ""
+            };
+            return &self;
+        }, "host"_a, "port"_a, "user"_a, "pw"_a);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // OpenAPIConfig
     py::class_<OpenAPIConfig>(m, "OAConfig")
             .def("__contains__", [](const OpenAPIConfig& self, std::string const& methodName) {
                 return self.methodPath.find(methodName) != self.methodPath.end();

--- a/libs/zswag/app.py
+++ b/libs/zswag/app.py
@@ -5,6 +5,7 @@ import zserio
 import sys
 import yaml
 from typing import Type
+from flask import request as flask_request
 
 from pyzswagcl import \
     parse_openapi_config, \
@@ -156,7 +157,11 @@ class OAServer(connexion.App):
                 if spec.body_request_object:
                     request_blob = kwargs["body"]
                 else:
-                    request_blob = request_object_blob(req_t=req_t, spec=spec, **kwargs)
+                    request_blob = request_object_blob(
+                        req_t=req_t,
+                        spec=spec,
+                        headers=flask_request.headers,
+                        **kwargs)
                 return bytes(fun(request_blob, None).byte_array)
             setattr(self.service_instance, method_name, wsgi_method)
 

--- a/libs/zswag/reflect.py
+++ b/libs/zswag/reflect.py
@@ -182,7 +182,7 @@ def parse_param_values(param: OAParam, target_type: Type, value: List[str]) -> L
 
 # Get a blob for a zserio request type, a set of request parameter values
 # and an OpenAPI method path spec.
-def request_object_blob(*, req_t: Type, spec: OAMethod, **kwargs) -> bytes:
+def request_object_blob(*, req_t: Type, headers: Dict[str, Any], spec: OAMethod, **kwargs) -> bytes:
     # Lazy instantiation of request object and type info
     req: Optional[req_t] = None
     req_field_types: Dict = {}
@@ -193,8 +193,12 @@ def request_object_blob(*, req_t: Type, spec: OAMethod, **kwargs) -> bytes:
     for param_name, param in spec.parameters.items():
         # Get raw string value
         value: Union[str, List[str]] = param.default_value
+        param_name = param_name.replace("-", "_")
         if param_name in kwargs:
-            value = kwargs[param_name.replace("-", "_")]
+            value = kwargs[param_name]
+        else:
+            if param_name in headers:
+                value = headers[param_name]
         # Convert string value to whole blob
         if param.field == ZSERIO_REQUEST_PART_WHOLE:
             return str_to_bytes(value, param.format)

--- a/libs/zswag/test/calc/api.yaml
+++ b/libs/zswag/test/calc/api.yaml
@@ -19,8 +19,8 @@ paths:
           schema:
             format: string
             type: string
-        - in: query
-          name: exponent
+        - in: header
+          name: X-Ponent
           required: true
           x-zserio-request-part: exponent.value
           schema:

--- a/libs/zswag/test/calc/client.py
+++ b/libs/zswag/test/calc/client.py
@@ -28,7 +28,7 @@ def run(host, port):
             print(f"[py-test-client]   -> ERROR: {str(e) or type(e).__name__}", flush=True)
 
     run_test(
-        "Pass fields in path and query",
+        "Pass fields in path and header",
         api.BaseAndExponent(api.I32(2), api.I32(3)),
         api.Calculator.Client.power,
         8.)

--- a/libs/zswag/test/client.cpp
+++ b/libs/zswag/test/client.cpp
@@ -53,7 +53,7 @@ int main (int argc, char* argv[]) {
                 {"base.value",     2},
                 {"exponent.value", 3}
         })).get<zsr::Introspectable>().value();
-    }, 8., "Pass fields in path and query");
+    }, 8., "Pass fields in path and header");
 
     runTest([](ZsrClient& zsrClient){
         return zsr::find<zsr::ServiceMethod>("calculator.Calculator.intSum")->call(

--- a/libs/zswagcl/include/zswagcl/openapi-client.hpp
+++ b/libs/zswagcl/include/zswagcl/openapi-client.hpp
@@ -15,7 +15,7 @@ namespace zswagcl
 class OpenAPIClient
 {
 public:
-    OpenAPIConfig config;
+    OpenAPIConfig config_;
 
     OpenAPIClient(OpenAPIConfig config,
                   std::unique_ptr<httpcl::IHttpClient> client);
@@ -38,6 +38,7 @@ public:
 
 private:
     std::unique_ptr<httpcl::IHttpClient> client_;
+    httpcl::Settings settings_;
 };
 
 }

--- a/libs/zswagcl/include/zswagcl/openapi-config.hpp
+++ b/libs/zswagcl/include/zswagcl/openapi-config.hpp
@@ -16,11 +16,11 @@ struct OpenAPIConfig
         enum Location {
             Path,
             Query,
+            Header
         } location = Query;
 
         /**
-         * Parameter identifier (from template) without style/explode
-         * hints ({?X*} -> X).
+         * Parameter identifier.
          */
         std::string ident;
 

--- a/libs/zswagcl/include/zswagcl/openapi-parameter-helper.hpp
+++ b/libs/zswagcl/include/zswagcl/openapi-parameter-helper.hpp
@@ -167,12 +167,16 @@ struct ParameterValue
     /**
      * Make query key-value pair.
      *
-     * Styles supported:
-     *   * Form
+     * For Query location, supported styles are:
+     *   * Form, explode=false
+     *   * Form, explode=true
+     *
+     * For Header location, supported styles are:
+     *   * Form, explode=false
      *
      * @see https://swagger.io/docs/specification/serialization/
      */
-    std::vector<std::pair<std::string, std::string>> queryPairs(const OpenAPIConfig::Parameter&) const;
+    std::vector<std::pair<std::string, std::string>> queryOrHeaderPairs(const OpenAPIConfig::Parameter&) const;
 };
 
 class ParameterValueHelper

--- a/libs/zswagcl/src/openapi-parameter-helper.cpp
+++ b/libs/zswagcl/src/openapi-parameter-helper.cpp
@@ -162,7 +162,7 @@ std::string ParameterValue::pathStr(const OpenAPIConfig::Parameter& param) const
 
 }
 
-std::vector<std::pair<std::string, std::string>> ParameterValue::queryPairs(const OpenAPIConfig::Parameter& param) const
+std::vector<std::pair<std::string, std::string>> ParameterValue::queryOrHeaderPairs(const OpenAPIConfig::Parameter& param) const
 {
     using Pair = std::pair<std::string, std::string>;
     using List = std::vector<Pair>;

--- a/libs/zswagcl/test/src/openapi-parameter-helper.cpp
+++ b/libs/zswagcl/test/src/openapi-parameter-helper.cpp
@@ -30,10 +30,10 @@ static auto pathStr(const Parameter& parameter, _Fun fun)
 }
 
 template <class _Fun>
-static auto queryPairs(const Parameter& parameter, _Fun fun)
+static auto queryOrHeaderPairs(const Parameter& parameter, _Fun fun)
 {
     ParameterValueHelper helper(parameter);
-    return fun(helper).queryPairs(parameter);
+    return fun(helper).queryOrHeaderPairs(parameter);
 }
 
 /* Testdata */
@@ -268,7 +268,7 @@ TEST_CASE("openapi query parameters", "[zswagcl::open-api-format-helper]") {
             auto explode = GENERATE(false, true);
             INFO("Explode: " << explode);
 
-            auto r = queryPairs(makeParameter("id", style, explode), [&](auto& helper) {
+            auto r = queryOrHeaderPairs(makeParameter("id", style, explode), [&](auto& helper) {
                 return helper.value(value);
             });
 
@@ -281,7 +281,7 @@ TEST_CASE("openapi query parameters", "[zswagcl::open-api-format-helper]") {
 
         SECTION("Array") {
             SECTION("Normal") {
-                auto r = queryPairs(makeParameter("id", style, false), [&](auto& helper) {
+                auto r = queryOrHeaderPairs(makeParameter("id", style, false), [&](auto& helper) {
                     return helper.array(list);
                 });
 
@@ -292,7 +292,7 @@ TEST_CASE("openapi query parameters", "[zswagcl::open-api-format-helper]") {
                 REQUIRE(v == "3,4,5");
             }
             SECTION("Explode") {
-                auto r = queryPairs(makeParameter("id", style, true), [&](auto& helper) {
+                auto r = queryOrHeaderPairs(makeParameter("id", style, true), [&](auto& helper) {
                     return helper.array(list);
                 });
 
@@ -308,7 +308,7 @@ TEST_CASE("openapi query parameters", "[zswagcl::open-api-format-helper]") {
 
         SECTION("Object") {
             SECTION("Normal") {
-                auto r = queryPairs(makeParameter("id", style, false), [&](auto& helper) {
+                auto r = queryOrHeaderPairs(makeParameter("id", style, false), [&](auto& helper) {
                     return helper.object(object);
                 });
 
@@ -319,7 +319,7 @@ TEST_CASE("openapi query parameters", "[zswagcl::open-api-format-helper]") {
                 REQUIRE(v == "firstName,Alex,role,admin");
             }
             SECTION("Explode") {
-                auto r = queryPairs(makeParameter("id", style, true), [&](auto& helper) {
+                auto r = queryOrHeaderPairs(makeParameter("id", style, true), [&](auto& helper) {
                     return helper.object(object);
                 });
 


### PR DESCRIPTION
### Changes

* Added support for OpenAPI parameter `in=header`
* Added support for custom `httpcl::Config` objects that can be passed into `ZsrClient`/`OAClient` to add transient query/header/cookie/proxy/auth configs.
* The OpenApiClient base class is now responsible for passing `httpcl::Config` to the `HttpLibHttpClient`. This is in preparation for #56 .

Note: Support for the `header` parameter location will not be added to `zswag.gen` for now.

### Follow-up work

* Some TODOs in OpenAPIParser for additional error messages will be done in the scope of #59 .
* Need to adjust the UML in the README.
* Need to add cookies/headers support to Settings YAML parser.

### Steps to reproduce

Have a look at the integration-tests. They test passing a value in the header.
Tests for the new programmatic HTTP settings API will be added in #56 .
