### PR TITLE
Consistent Content Type Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Simply run `pip install zswag`. **Note: This only works with ...**
 Using CMake, you can ...
 
 * 🌟run tests.
-* 🌟build the zswag wheels for Python != 3.8.
+* 🌟build the zswag wheels for a custom Python version.
 * 🌟[integrate the C++ client into a C++ project.](#c-client)
 
 The basic setup follows the usual CMake configure/build steps:

--- a/libs/httpcl/include/httpcl/http-client.hpp
+++ b/libs/httpcl/include/httpcl/http-client.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <functional>
 #include <map>
+#include <optional>
 #include <stdexcept>
 
 #include "http-settings.hpp"
@@ -13,9 +14,17 @@
 namespace httpcl
 {
 
+struct BodyAndContentType {
+    std::string body;
+    std::string contentType;
+};
+
+using OptionalBodyAndContentType = std::optional<BodyAndContentType>;
+
 class IHttpClient
 {
 public:
+
     struct Result {
         int status;
         std::string content;
@@ -35,20 +44,16 @@ public:
     virtual Result get(const std::string& path,
                        const Config& config) = 0;
     virtual Result post(const std::string& path,
-                        const std::string& body,
-                        const std::string& bodyType,
+                        const OptionalBodyAndContentType& body,
                         const Config& config) = 0;
     virtual Result put(const std::string& path,
-                       const std::string& body,
-                       const std::string& bodyType,
+                       const OptionalBodyAndContentType& body,
                        const Config& config) = 0;
     virtual Result del(const std::string& path,
-                       const std::string& body,
-                       const std::string& bodyType,
+                       const OptionalBodyAndContentType& body,
                        const Config& config) = 0;
     virtual Result patch(const std::string& path,
-                         const std::string& body,
-                         const std::string& bodyType,
+                         const OptionalBodyAndContentType& body,
                          const Config& config) = 0;
 };
 
@@ -61,20 +66,16 @@ public:
     Result get(const std::string& uri,
                const Config& config) override;
     Result post(const std::string& uri,
-                const std::string& body,
-                const std::string& bodyType,
+                const OptionalBodyAndContentType& body,
                 const Config& config) override;
     Result put(const std::string& uri,
-               const std::string& body,
-               const std::string& bodyType,
+               const OptionalBodyAndContentType& body,
                const Config& config) override;
     Result del(const std::string& uri,
-               const std::string& body,
-               const std::string& bodyType,
+               const OptionalBodyAndContentType& body,
                const Config& config) override;
     Result patch(const std::string& uri,
-                 const std::string& body,
-                 const std::string& bodyType,
+                 const OptionalBodyAndContentType& body,
                  const Config& config) override;
 
 private:
@@ -85,28 +86,28 @@ private:
 class MockHttpClient : public IHttpClient
 {
 public:
-    std::function<IHttpClient::Result(std::string_view /* uri */)> getFun;
-    std::function<IHttpClient::Result(std::string_view /* uri */,
-                                      std::string_view /* body */,
-                                      std::string_view /* type */)> postFun;
+    std::function<
+        IHttpClient::Result(std::string_view /* uri */)
+    > getFun;
+    std::function<
+        IHttpClient::Result(
+            std::string_view /* uri */,
+            OptionalBodyAndContentType const& /* body */
+    )> postFun;
 
     Result get(const std::string& uri,
                const Config& config) override;
     Result post(const std::string& uri,
-                const std::string& body,
-                const std::string& bodyType,
+                const OptionalBodyAndContentType& body,
                 const Config& config) override;
     Result put(const std::string& uri,
-               const std::string& body,
-               const std::string& bodyType,
+               const OptionalBodyAndContentType& body,
                const Config& config) override;
     Result del(const std::string& uri,
-               const std::string& body,
-               const std::string& bodyType,
+               const OptionalBodyAndContentType& body,
                const Config& config) override;
     Result patch(const std::string& uri,
-                 const std::string& body,
-                 const std::string& bodyType,
+                 const OptionalBodyAndContentType& body,
                  const Config& config) override;
 };
 

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -70,55 +70,51 @@ Result HttpLibHttpClient::get(const std::string& uriStr,
 }
 
 Result HttpLibHttpClient::post(const std::string& uriStr,
-                               const std::string& body,
-                               const std::string& bodyType,
+                               const std::optional<BodyAndContentType>& body,
                                const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
     return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Post(
         uri.buildPath().c_str(),
         {config.headers.begin(), config.headers.end()},
-        body,
-        bodyType.c_str()));
+        body ? body->body : std::string(),
+        body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::put(const std::string& uriStr,
-                              const std::string& body,
-                              const std::string& bodyType,
+                              const std::optional<BodyAndContentType>& body,
                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
     return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Put(
         uri.buildPath().c_str(),
         {config.headers.begin(), config.headers.end()},
-        body,
-        bodyType.c_str()));
+        body ? body->body : std::string(),
+        body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::del(const std::string& uriStr,
-                              const std::string& body,
-                              const std::string& bodyType,
+                              const std::optional<BodyAndContentType>& body,
                               const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
     return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Delete(
         uri.buildPath().c_str(),
         {config.headers.begin(), config.headers.end()},
-        body,
-        bodyType.c_str()));
+        body ? body->body : std::string(),
+        body ? body->contentType.c_str() : nullptr));
 }
 
 Result HttpLibHttpClient::patch(const std::string& uriStr,
-                                const std::string& body,
-                                const std::string& bodyType,
+                                const std::optional<BodyAndContentType>& body,
                                 const Config& config)
 {
     auto uri = URIComponents::fromStrRfc3986(uriStr);
     return makeResult(impl_->makeClientAndApplyQuery(uri, config)->Patch(
         uri.buildPath().c_str(),
         {config.headers.begin(), config.headers.end()},
-        body,
-        bodyType.c_str()));
+        body ? body->body : std::string(),
+        body ? body->contentType.c_str() : nullptr));
 }
 
 Result MockHttpClient::get(const std::string& uri,
@@ -132,36 +128,32 @@ Result MockHttpClient::get(const std::string& uri,
 }
 
 Result MockHttpClient::post(const std::string& uri,
-                            const std::string& body,
-                            const std::string& bodyType,
+                            const std::optional<BodyAndContentType>& body,
                             const Config& config)
 {
     auto uriWithQuery = URIComponents::fromStrRfc3986(uri);
     applyQuery(uriWithQuery, config);
     if (postFun)
-        return postFun(uriWithQuery.build(), body, bodyType);
+        return postFun(uriWithQuery.build(), body);
     return {0, ""};
 }
 
 Result MockHttpClient::put(const std::string& uri,
-                           const std::string& body,
-                           const std::string& bodyType,
+                           const std::optional<BodyAndContentType>& body,
                            const Config& config)
 {
     return {0, ""};
 }
 
 Result MockHttpClient::del(const std::string& uri,
-                           const std::string& body,
-                           const std::string& bodyType,
+                           const std::optional<BodyAndContentType>& body,
                            const Config& config)
 {
     return {0, ""};
 }
 
 Result MockHttpClient::patch(const std::string& uri,
-                             const std::string& body,
-                             const std::string& bodyType,
+                             const std::optional<BodyAndContentType>& body,
                              const Config& config)
 {
     return {0, ""};

--- a/libs/zswag/gen.py
+++ b/libs/zswag/gen.py
@@ -157,7 +157,7 @@ class OpenApiSchemaGenerator:
                             "200": {
                                 "description": method_info.returndoc,
                                 "content": {
-                                    "application/octet-stream": {
+                                    ZSERIO_OBJECT_CONTENT_TYPE: {
                                         "schema": {
                                             "type": "string",
                                             "format": "binary"

--- a/libs/zswag/test/calc/api.yaml
+++ b/libs/zswag/test/calc/api.yaml
@@ -30,7 +30,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 type: string
       summary: ''
@@ -52,7 +52,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -74,7 +74,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -97,7 +97,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -120,7 +120,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -142,7 +142,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -159,7 +159,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -181,7 +181,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -201,7 +201,7 @@ paths:
         '200':
           description: ''
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string

--- a/libs/zswag/test/test_openapi_generator_1.yaml
+++ b/libs/zswag/test/test_openapi_generator_1.yaml
@@ -24,7 +24,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -48,7 +48,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -72,7 +72,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -96,7 +96,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -118,7 +118,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -142,7 +142,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -166,7 +166,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -188,7 +188,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -252,7 +252,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string

--- a/libs/zswag/test/test_openapi_generator_2.yaml
+++ b/libs/zswag/test/test_openapi_generator_2.yaml
@@ -21,7 +21,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -45,7 +45,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -69,7 +69,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -93,7 +93,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -115,7 +115,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -139,7 +139,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -163,7 +163,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -185,7 +185,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string
@@ -249,7 +249,7 @@ paths:
       responses:
         '200':
           content:
-            application/octet-stream:
+            application/x-zserio-object:
               schema:
                 format: binary
                 type: string

--- a/libs/zswagcl/src/openapi-client.cpp
+++ b/libs/zswagcl/src/openapi-client.cpp
@@ -107,26 +107,28 @@ std::string OpenAPIClient::call(const std::string& methodIdent,
         if (httpMethod == "GET") {
             return  client_->get(uri.build(), httpConfig);
         } else {
-            std::string body, bodyType;
+            httpcl::OptionalBodyAndContentType body;
             if (method.bodyRequestObject) {
-                bodyType = ZSERIO_OBJECT_CONTENT_TYPE;
+                body = httpcl::BodyAndContentType{
+                    "", ZSERIO_OBJECT_CONTENT_TYPE
+                };
 
                 OpenAPIConfig::Parameter bodyParameter;
                 bodyParameter.ident = "body";
                 bodyParameter.format = OpenAPIConfig::Parameter::Format::Binary;
 
                 ParameterValueHelper bodyHelper(bodyParameter);
-                body = paramCb("", ZSERIO_REQUEST_PART_WHOLE, bodyHelper).bodyStr();
+                body->body = paramCb("", ZSERIO_REQUEST_PART_WHOLE, bodyHelper).bodyStr();
             }
 
             if (httpMethod == "POST")
-                return client_->post(uri.build(), body, bodyType, httpConfig);
+                return client_->post(uri.build(), body, httpConfig);
             if (httpMethod == "PUT")
-                return client_->put(uri.build(), body, bodyType, httpConfig);
+                return client_->put(uri.build(), body, httpConfig);
             if (httpMethod == "PATCH")
-                return client_->patch(uri.build(), body, bodyType, httpConfig);
+                return client_->patch(uri.build(), body, httpConfig);
             if (httpMethod == "DELETE")
-                return client_->del(uri.build(), body, bodyType, httpConfig);
+                return client_->del(uri.build(), body, httpConfig);
 
             throw std::runtime_error(stx::format(
                 "Unsupported HTTP method '{}' (uri: {})",

--- a/libs/zswagcl/test/src/zsr-client.cpp
+++ b/libs/zswagcl/test/src/zsr-client.cpp
@@ -229,11 +229,11 @@ TEST_CASE("HTTP-Service", "[zsr-client]") {
         /* Setup mock client */
         auto client = std::make_unique<httpcl::MockHttpClient>();
         client->postFun = [&](std::string_view uri,
-                              std::string_view body,
-                              std::string_view type) {
+                              httpcl::OptionalBodyAndContentType const& body) {
             REQUIRE(uri == "https://my.server.com/api/post/hello");
-            REQUIRE(type == ZSERIO_OBJECT_CONTENT_TYPE);
-            REQUIRE(std::equal(body.begin(), body.end(),
+            REQUIRE(body);
+            REQUIRE(body->contentType == ZSERIO_OBJECT_CONTENT_TYPE);
+            REQUIRE(std::equal(body->body.begin(), body->body.end(),
                                buffer.begin(), buffer.end()));
 
             postCalled = true;


### PR DESCRIPTION
### Changes

* Do not send empty content type when no body is being sent.
* Use `application/x-zserio-object` for both requests and responses.

Closes #52 