### PR TITLE
Extended Logging 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,11 @@ if (NOT TARGET wheel)
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/deps/python-cmake-wheel")
   include(python-wheel)
   set(WHEEL_DEPLOY_DIRECTORY "${ZSWAG_DEPLOY_DIR}/wheel")
-endif ()
+endif()
 
 if (NOT TARGET yaml-cpp)
   add_subdirectory(deps/yaml-cpp)
-endif ()
+endif()
 
 if (NOT TARGET stx)
   FetchContent_Declare(stx
@@ -55,9 +55,17 @@ if (NOT TARGET speedyj)
   FetchContent_MakeAvailable(speedyj)
 endif()
 
+if (NOT TARGET spdlog)
+  FetchContent_Declare(spdlog
+    GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
+    GIT_TAG        "v1.x"
+    GIT_SHALLOW    ON)
+  FetchContent_MakeAvailable(spdlog)
+endif()
+
 if (NOT TARGET Catch2)
   add_subdirectory(deps/Catch2)
-endif ()
+endif()
 
 if (NOT TARGET httplib)
   add_subdirectory(deps/cpp-httplib)
@@ -65,20 +73,20 @@ if (NOT TARGET httplib)
     INTERFACE
     CPPHTTPLIB_OPENSSL_SUPPORT)
   target_link_libraries(httplib INTERFACE OpenSSL::SSL)
-endif ()
+endif()
 
 if (NOT TARGET keychain)
   add_subdirectory(deps/keychain)
-endif ()
+endif()
 
 if (NOT TARGET pybind11)
   add_subdirectory(deps/pybind11)
-endif ()
+endif()
 
 if (NOT TARGET ZserioCppRuntime)
   add_subdirectory(deps/zserio/compiler/extensions/cpp/runtime/src)
   set(ZSERIO_REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/deps/zserio")
-endif ()
+endif()
 
 if (NOT TARGET zserio-cmake-helper)
   add_subdirectory(deps/zserio-cmake-helper)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ struct Response {
 };
 
 service MyService {
-  Response my_api(Request);
+  Response myApi(Request);
 };
 ```
 
@@ -440,8 +440,9 @@ int main (int argc, char* argv[])
     // Create the request object
     auto request = myapp_services::services::Request(2);
 
-    // Invoke the REST endpoint
-    auto response = myServiceClient.my_api(request);
+    // Invoke the REST endpoint. Mind that your method-
+    // name from the schema is appended with a "...Method" suffix.
+    auto response = myServiceClient.myApiMethod(request);
     
     // Print the response
     std::cout << "Got " << response.getValue() << std::endl;
@@ -457,6 +458,20 @@ int main (int argc, char* argv[])
    default persistent configuration. If you would like to prevent persistent
    config from being considered at all, set `HTTP_SETTINGS_FILE` to empty,
    e.g. via `setenv`.
+
+## Client Environment Settings
+
+Both the Python and C++ Clients can be configured using the following
+environment variables:
+
+| Variable Name | Details   |
+| ------------- | --------- |
+| `HTTP_SETTINGS_FILE` | Path to settings file for HTTP proxies and authentication, see [next section](#persistent-http-headers-proxy-cookie-and-authentication) |
+| `HTTP_LOG_LEVEL` | Verbosity level for console/log output. Set to `debug` for detailed output. |
+| `HTTP_LOG_FILE` | Logfile-path (including filename) to redirect console output. The log will rotate with three files (`HTTP_LOG_FILE`, `HTTP_LOG_FILE-1`, `HTTP_LOG_FILE-2`). |
+| `HTTP_LOG_FILE_MAXSIZE` | Maximum size of the logfile, in bytes. Defaults to 1GB. |
+| `HTTP_TIMEOUT` | Timeout for HTTP requests (connection+transfer) in seconds. Defaults to 60s. |
+| `HTTP_SSL_STRICT` | Set to any nonempty value for strict SSL certificate validation. |
 
 ## Persistent HTTP Headers, Proxy, Cookie and Authentication
 

--- a/libs/httpcl/CMakeLists.txt
+++ b/libs/httpcl/CMakeLists.txt
@@ -7,9 +7,11 @@ add_library(httpcl STATIC
   include/httpcl/http-client.hpp
   include/httpcl/http-settings.hpp
   include/httpcl/uri.hpp
+  include/httpcl/log.hpp
   src/http-client.cpp
   src/http-settings.cpp
-  src/uri.cpp)
+  src/uri.cpp
+  src/log.cpp)
 
 target_compile_features(httpcl
   INTERFACE
@@ -19,6 +21,7 @@ target_link_libraries(httpcl
   PRIVATE
     stx
   PUBLIC
+    spdlog
     keychain
     httplib::httplib
     yaml-cpp

--- a/libs/httpcl/include/httpcl/http-client.hpp
+++ b/libs/httpcl/include/httpcl/http-client.hpp
@@ -63,6 +63,8 @@ public:
 class HttpLibHttpClient : public IHttpClient
 {
 public:
+    HttpLibHttpClient();
+
     Result get(const std::string& uri,
                const Config& config) override;
     Result post(const std::string& uri,
@@ -77,6 +79,9 @@ public:
     Result patch(const std::string& uri,
                  const OptionalBodyAndContentType& body,
                  const Config& config) override;
+private:
+    time_t timeoutSecs_ = 60.;
+    bool sslCertStrict_ = false;
 };
 
 class MockHttpClient : public IHttpClient

--- a/libs/httpcl/include/httpcl/http-client.hpp
+++ b/libs/httpcl/include/httpcl/http-client.hpp
@@ -10,6 +10,7 @@
 
 #include "http-settings.hpp"
 #include "uri.hpp"
+#include "log.hpp"
 
 namespace httpcl
 {
@@ -36,7 +37,9 @@ public:
         Error(Result result, std::string const& message)
             : std::runtime_error(message)
             , result(std::move(result))
-        {}
+        {
+            log().error(message);
+        }
     };
 
     virtual ~IHttpClient() = default;

--- a/libs/httpcl/include/httpcl/log.hpp
+++ b/libs/httpcl/include/httpcl/log.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "spdlog/spdlog.h"
+
+namespace httpcl
+{
+
+/**
+ * Obtain global logger, which is initialized from
+ * the following environment variables:
+ *  - HTTP_LOG_LEVEL
+ *  - HTTP_LOG_FILE
+ *  - HTTP_LOG_FILE_MAXSIZE
+ */
+spdlog::logger& log();
+
+/**
+ * Log a runtime error and return the throwable object.
+ * @param what Runtime error message.
+ * @return std::runtime_error to throw.
+ */
+template<typename error_t = std::runtime_error>
+error_t logRuntimeError(std::string const& what) {
+    log().error(what);
+    return error_t(what);
+}
+
+}

--- a/libs/httpcl/src/http-client.cpp
+++ b/libs/httpcl/src/http-client.cpp
@@ -1,8 +1,6 @@
 #include "http-client.hpp"
 #include "uri.hpp"
 
-#include "httpcl/http-settings.hpp"
-
 #include <httplib.h>
 
 namespace

--- a/libs/httpcl/src/log.cpp
+++ b/libs/httpcl/src/log.cpp
@@ -40,7 +40,12 @@ spdlog::logger& httpcl::log()
         if (!logFile.empty()) {
             std::cerr << "Logging OpenAPI HTTP events to '" << logFile << "'!" << std::endl;
             if (!logFileMaxSize.empty()) {
-                logFileMaxSizeInt = std::stoul(logFileMaxSize);
+                try {
+                    logFileMaxSizeInt = std::stoull(logFileMaxSize);
+                }
+                catch (std::exception& e) {
+                    std::cerr << "Could not parse value of HTTP_LOG_FILE_MAXSIZE." << std::endl;
+                }
             }
             std::cerr << "Maximum logfile size is " << logFileMaxSizeInt << " bytes!" << std::endl;
             httpLogger = spdlog::rotating_logger_mt("openapi-http", logFile, logFileMaxSizeInt, 2);

--- a/libs/httpcl/src/log.cpp
+++ b/libs/httpcl/src/log.cpp
@@ -1,0 +1,67 @@
+#include "log.hpp"
+#include <shared_mutex>
+#include <iostream>
+#include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+spdlog::logger& httpcl::log()
+{
+    static std::shared_ptr<spdlog::logger> httpLogger;
+    static std::shared_mutex loggerAccess;
+
+    {
+        // Check if the logger is already initialized - read-only lock
+        std::shared_lock<std::shared_mutex> readLock(loggerAccess);
+        if (httpLogger)
+            return *httpLogger;
+    }
+
+    {
+        // Get write lock
+        std::lock_guard<std::shared_mutex> readLock(loggerAccess);
+
+        // Check again, another thread might have initialized now
+        if (httpLogger)
+            return *httpLogger;
+
+        // Initialize the logger
+        auto getEnvSafe = [](char const* env){
+            auto value = std::getenv(env);
+            if (value)
+                return std::string(value);
+            return std::string();
+        };
+        std::string logLevel = getEnvSafe("HTTP_LOG_LEVEL");
+        std::string logFile = getEnvSafe("HTTP_LOG_FILE");
+        std::string logFileMaxSize = getEnvSafe("HTTP_LOG_FILE_MAXSIZE");
+        uint64_t logFileMaxSizeInt = 1024ull*1024*1024; // 1GB
+
+        // File logger on demand, otherwise console logger
+        if (!logFile.empty()) {
+            std::cerr << "Logging OpenAPI HTTP events to '" << logFile << "'!" << std::endl;
+            if (!logFileMaxSize.empty()) {
+                logFileMaxSizeInt = std::stoul(logFileMaxSize);
+            }
+            std::cerr << "Maximum logfile size is " << logFileMaxSizeInt << " bytes!" << std::endl;
+            httpLogger = spdlog::rotating_logger_mt("openapi-http", logFile, logFileMaxSizeInt, 2);
+        }
+        else
+            httpLogger = spdlog::stderr_color_mt("openapi-http");
+
+        // Parse/set log level
+        for (auto& ch : logLevel)
+            ch = std::tolower(ch);
+        if (logLevel == "error" || logLevel == "err")
+            httpLogger->set_level(spdlog::level::err);
+        else if (logLevel == "warning" || logLevel == "warn")
+            httpLogger->set_level(spdlog::level::warn);
+        else if (logLevel == "info")
+            httpLogger->set_level(spdlog::level::info);
+        else if (logLevel == "debug" || logLevel == "dbg")
+            httpLogger->set_level(spdlog::level::debug);
+        else if (logLevel == "trace")
+            httpLogger->set_level(spdlog::level::trace);
+    }
+
+    return *httpLogger;
+}

--- a/libs/httpcl/src/uri.cpp
+++ b/libs/httpcl/src/uri.cpp
@@ -4,6 +4,9 @@
 #include <cstring>
 #include <cctype>
 
+#include "httpcl/log.hpp"
+#include "stx/format.h"
+
 namespace httpcl
 {
 
@@ -228,9 +231,8 @@ URIComponents URIComponents::fromStrRfc3986(std::string const& uri)
     if (!parsePath(c, &result.path)) error = "Error parsing path";
     if (*c == '?' && !parseQuery(++c, &result.query)) error = "Error parsing query";
 
-    if (!error.empty()){
-        error += " of URI '" + uri + "'";
-        throw URIError(std::move(error));
+    if (!error.empty()) {
+        throw logRuntimeError<URIError>(stx::format("[URIComponents::fromStrRfc3986] {} of URI '{}'", error, uri));
     }
 
     return result;
@@ -241,11 +243,13 @@ URIComponents URIComponents::fromStrPath(std::string const& pathAndQueryString) 
     const auto* c = pathAndQueryString.c_str();
 
     if (!parsePath(c, &result.path))
-        throw URIError("Error parsing path");
+        throw logRuntimeError<URIError>(
+            stx::format("[URIComponents::fromStrPath] Error parsing path from '{}'", pathAndQueryString));
 
     if (*c == '?')
         if (!parseQuery(++c, &result.query))
-            throw URIError("Error parsing query");
+            throw logRuntimeError<URIError>(
+                stx::format("[URIComponents::fromStrPath] Error parsing query from '{}'", pathAndQueryString));
 
     return result;
 }
@@ -303,10 +307,10 @@ std::string URIComponents::build() const
 std::string URIComponents::buildHost() const
 {
     if (scheme.empty())
-        throw URIError("Missing scheme");
+        throw logRuntimeError<URIError>("[URIComponents::buildHost] Missing scheme");
 
     if (host.empty())
-        throw URIError("Missing host");
+        throw logRuntimeError<URIError>("[URIComponents::buildHost] Missing host");
 
     return scheme + "://" +
            host +

--- a/libs/zswag/test/client.cpp
+++ b/libs/zswag/test/client.cpp
@@ -25,23 +25,23 @@ int main (int argc, char* argv[]) {
         spdlog::info("[cpp-test-client] Executing test #{}: {} ...", testCounter, aspect);
         try
         {
-            spdlog::info("[cpp-test-client]   → Instantiating client.");
+            spdlog::info("[cpp-test-client]   => Instantiating client.");
             auto httpClient = std::make_unique<HttpLibHttpClient>();
             auto openApiConfig = fetchOpenAPIConfig(specUrl, *httpClient);
             httpcl::Config authHttpConf;
             authFun(authHttpConf);
             auto oaClient = OAClient(openApiConfig, std::move(httpClient), authHttpConf);
-            spdlog::info("[cpp-test-client]   → Running request.");
+            spdlog::info("[cpp-test-client]   => Running request.");
             calculator::Calculator::Client calcClient(oaClient);
             auto response = fn(calcClient);
             if (response.getValue() == expect)
-                spdlog::info("[cpp-test-client]   → Success.");
+                spdlog::info("[cpp-test-client]   => Success.");
             else
                 throw std::runtime_error(stx::format("Expected {}, got {}!", expect, response.getValue()));
         }
         catch(std::exception const& e) {
             ++failureCounter;
-            spdlog::error("[cpp-test-client]   → ERROR: {}", e.what());
+            spdlog::error("[cpp-test-client]   => ERROR: {}", e.what());
         }
     };
 

--- a/libs/zswag/test/client.cpp
+++ b/libs/zswag/test/client.cpp
@@ -1,7 +1,6 @@
 #include "zswagcl/oaclient.hpp"
 #include "stx/format.h"
-
-#include <iostream>
+#include "spdlog/spdlog.h"
 
 #include "calculator/Calculator.h"
 
@@ -10,7 +9,7 @@ using namespace httpcl;
 
 int main (int argc, char* argv[]) {
     if(argc <= 1) {
-        std::cerr << "[cpp-test-client] ERROR: The first argument must be the OpenAPI spec URL." << std::endl;
+        spdlog::error("[cpp-test-client] ERROR: The first argument must be the OpenAPI spec URL.");
         exit(1);
     }
 
@@ -18,31 +17,31 @@ int main (int argc, char* argv[]) {
     auto testCounter = 0;
     auto failureCounter = 0;
 
-    std::cout << "[cpp-test-client] Starting integration tests with " << specUrl << "\n";
+    spdlog::info("[cpp-test-client] Starting integration tests with {}", specUrl);
 
     auto runTest = [&] (auto const& fn, auto expect, std::string const& aspect, std::function<void(httpcl::Config&)> const& authFun)
     {
         ++testCounter;
-        std::cout << stx::format("[cpp-test-client] Executing test #{}: {} ...", testCounter, aspect) << std::endl;
+        spdlog::info("[cpp-test-client] Executing test #{}: {} ...", testCounter, aspect);
         try
         {
-            std::cout << "[cpp-test-client]   → Instantiating client." << std::endl;
+            spdlog::info("[cpp-test-client]   → Instantiating client.");
             auto httpClient = std::make_unique<HttpLibHttpClient>();
             auto openApiConfig = fetchOpenAPIConfig(specUrl, *httpClient);
             httpcl::Config authHttpConf;
             authFun(authHttpConf);
             auto oaClient = OAClient(openApiConfig, std::move(httpClient), authHttpConf);
-            std::cout << "[cpp-test-client]   → Running request." << std::endl;
+            spdlog::info("[cpp-test-client]   → Running request.");
             calculator::Calculator::Client calcClient(oaClient);
             auto response = fn(calcClient);
             if (response.getValue() == expect)
-                std::cout << "[cpp-test-client]   → Success." << std::endl;
+                spdlog::info("[cpp-test-client]   → Success.");
             else
                 throw std::runtime_error(stx::format("Expected {}, got {}!", expect, response.getValue()));
         }
         catch(std::exception const& e) {
             ++failureCounter;
-            std::cout << stx::format("[cpp-test-client]   → ERROR: {}", e.what()) << std::endl;
+            spdlog::error("[cpp-test-client]   → ERROR: {}", e.what());
         }
     };
 
@@ -127,8 +126,8 @@ int main (int argc, char* argv[]) {
     });
 
     if (failureCounter > 0) {
-        std::cout << stx::format("[cpp-test-client] Done, {} test(s) failed!", failureCounter);
+        spdlog::error("[cpp-test-client] Done, {} test(s) failed!", failureCounter);
         exit(1);
     }
-    std::cout << stx::format("[cpp-test-client] All tests succeeded.", failureCounter);
+    spdlog::info("[cpp-test-client] All tests succeeded.");
 }


### PR DESCRIPTION
When using zswag, you can now use the environment variables `HTTP_LOG_LEVEL`, `HTTP_LOG_FILE` and `HTTP_LOG_FILE_MAXSIZE` to control the output behavior. When using `HTTP_LOG_LEVEL=debug`, zswag will now be very verbose. The logfiles are written in a rotating manner.

Fixes #68 